### PR TITLE
Add command line flag to load level directly

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 CXX := g++
-CXXFLAGS := -std=c++17 -Iinclude
+CXXFLAGS := -std=c++17 -Iinclude -g
 LDFLAGS := -lSDL2 -lSDL2_image -lSDL2_mixer -lstdc++fs
 OBJS = $(addprefix build/, main.o graphics.o character.o)
 EXECNAME = OpenManifold

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 CXX := g++
-CXXFLAGS := -std=c++17 -Iinclude -g
+CXXFLAGS := -std=c++17 -Iinclude
 LDFLAGS := -lSDL2 -lSDL2_image -lSDL2_mixer -lstdc++fs
 OBJS = $(addprefix build/, main.o graphics.o character.o)
 EXECNAME = OpenManifold

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -184,6 +184,20 @@ bool parse_option(char** argc, char** argv, const string& opt) {
     return std::find(argc, argv, opt) != argv;
 }
 
+/**
+ * Returns a pointer to the string of the argument that follows opt. If no argument
+ * follows it (ie if the flag or value is not provided) it returns `nullptr`.
+ */
+char *parse_option_value(char **argc, char **argv, const string& opt) {
+    char **flag = std::find(argc, argv, opt);
+    // Check for `argv - 1` (missing argument) and also `argv` (missing flag) in the same check.
+    if (flag >= argv - 1) {
+        return nullptr;
+    } else {
+        return *(flag + 1);
+    }
+}
+
 string get_version_string() {
     return "v" + std::to_string(VERSION_MAJOR) + "." + std::to_string(VERSION_MINOR) + "." + std::to_string(VERSION_PATCH);
 }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -25,6 +25,7 @@
 #include <cstdio>
 #include <cstdlib>
 #include <cmath>
+#include <cstring>
 #include <ctime>
 #include <string>
 #include <iostream>
@@ -1696,11 +1697,17 @@ int main(int argc, char *argv[]) {
     game_states transition_state;
     SDL_Event evt;
 
-    char *startup_level = parse_option_value(argv, argv+argc, "-i");
-    if (startup_level) {
-        printf("Startup level: %s\n", startup_level);
+    char *opt_startup_level = parse_option_value(argv, argv+argc, "-i");
+    if (opt_startup_level) {
+        string startup_level = opt_startup_level;
+
+        // Strip json file (if any)
+        if (startup_level.substr(startup_level.size() - 5, 5) == ".json") {
+            startup_level.erase(startup_level.begin() + startup_level.find_last_of("/"), startup_level.end());
+        }
+
+        // Load the level
         level_paths.push_back(startup_level);
-        level_index = 0;
         json_file = parse_level_file(get_level_json_path());
         start_level();
         transition_state = GAME;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1665,7 +1665,6 @@ bool loop(json json_file, int start_offset, int time_signature_top, int time_sig
 }
 
 void start_level() {
-    Mix_PlayChannel(0, snd_menu_confirm, 0);
     Mix_HaltMusic();
     reset_shapes();
     reset_sequences();
@@ -1866,6 +1865,7 @@ int main(int argc, char *argv[]) {
                             case CROSS:
                                 if (json_file == NULL) {break;}
                                 if (check_fade_in_activity()) {
+                                    Mix_PlayChannel(0, snd_menu_confirm, 0);
                                     start_level();
                                     transition_state = GAME;
                                     fade_out++;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1250,15 +1250,18 @@ void load_default_sound_collection() {
     return;
 }
 
+/**
+ * returns true if either fade value is anything other than 0
+ * in other words, this is true as long as any fade is happening
+ */
 bool check_fade_activity() {
-    // returns true if either fade value is anything other than 0
-    // in other words, this is true as long as any fade is happening
-    if (fade_in != 0 || fade_out != 0) {return true;} else return false;
+    return fade_in != 0 || fade_out != 0;
 }
-
+/**
+ * similar to check_fade_activity, but allows fade_in to be active
+ */
 bool check_fade_in_activity() {
-    // similar to check_fade_activity, but allows fade_in to be active
-    if ((fade_in <= 1) && (fade_out == 0)) {return true;} else return false;
+    return (fade_in <= 1) && (fade_out == 0);
 }
 
 void fade_reset() {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1664,7 +1664,7 @@ bool loop(json json_file, int start_offset, int time_signature_top, int time_sig
     return true;
 }
 
-void start_level(game_states *transition_state) {
+void start_level() {
     Mix_PlayChannel(0, snd_menu_confirm, 0);
     Mix_HaltMusic();
     reset_shapes();
@@ -1703,7 +1703,7 @@ int main(int argc, char *argv[]) {
         level_paths.push_back(startup_level);
         level_index = 0;
         json_file = parse_level_file(get_level_json_path());
-        start_level(&transition_state);
+        start_level();
         transition_state = GAME;
         fade_out = 255;
     }
@@ -1866,7 +1866,7 @@ int main(int argc, char *argv[]) {
                             case CROSS:
                                 if (json_file == NULL) {break;}
                                 if (check_fade_in_activity()) {
-                                    start_level(&transition_state);
+                                    start_level();
                                     transition_state = GAME;
                                     fade_out++;
                                 }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1704,7 +1704,8 @@ int main(int argc, char *argv[]) {
         level_index = 0;
         json_file = parse_level_file(get_level_json_path());
         start_level(&transition_state);
-        current_state = GAME;
+        transition_state = GAME;
+        fade_out = 255;
     }
     
     // parses arguments related to skipping directly to a given game state

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -2292,6 +2292,10 @@ int main(int argc, char *argv[]) {
                     unload_logo();
                     break;
 
+                case WARNING:
+                    load_default_music("menu");
+                    break;
+
                 default:
                     break;
             }
@@ -2302,7 +2306,6 @@ int main(int argc, char *argv[]) {
             // Runs functions at the start of a state
             switch (current_state) {
                 case TITLE:
-                    load_default_music("menu");
                     load_logo();
                     break;
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -218,7 +218,7 @@ void print_help() {
     "-tf / -true-fullscreen - Enable 'real' fullscreen\n"
     "-v  / -vsync           - Enable V-Sync\n"
     "-d  / -debug           - Enable debug features\n"
-    "-i [FILEPATH]          - Load a level on start\n");
+    "-i [FOLDER PATH]       - Specify a level folder to play on start\n");
     return;
 }
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -2292,10 +2292,6 @@ int main(int argc, char *argv[]) {
                     unload_logo();
                     break;
 
-                case WARNING:
-                    load_default_music("menu");
-                    break;
-
                 default:
                     break;
             }
@@ -2306,6 +2302,7 @@ int main(int argc, char *argv[]) {
             // Runs functions at the start of a state
             switch (current_state) {
                 case TITLE:
+                    load_default_music("menu");
                     load_logo();
                     break;
 


### PR DESCRIPTION
Using the `-i [FILEPATH]` argument you can choose a level to load directly on game launch. Fixes https://github.com/open-manifold/Open-Manifold/issues/7.