### PR TITLE
Use `#pragma once`

### DIFF
--- a/src/background.h
+++ b/src/background.h
@@ -1,5 +1,4 @@
-#ifndef background
-#define background
+#pragma once
 
 // contains all the background effect IDs
 // strings are converted to this and used internally
@@ -37,5 +36,3 @@ struct bg_data {
     int measure_length;
     SDL_Color grid_color;
 };
-
-#endif

--- a/src/character.h
+++ b/src/character.h
@@ -1,5 +1,4 @@
-#ifndef character
-#define character
+#pragma once
 
 struct character_frames {
     std::vector<SDL_Rect> idle;
@@ -22,5 +21,3 @@ void reset_character_status();
 void set_character_timer(int);
 void tick_character(int);
 SDL_Rect get_character_rect(int);
-
-#endif

--- a/src/graphics.h
+++ b/src/graphics.h
@@ -1,7 +1,6 @@
-#include "background.h"
+#pragma once
 
-#ifndef graphics
-#define graphics
+#include "background.h"
 
 // dedicated struct for a shape, cleaner and faster than using JSON arrays
 struct shape {
@@ -48,5 +47,3 @@ bool draw_level_select(nlohmann::json, int);
 bool draw_game(int, int, int, int, float, int, int, bool, bool, background_effect, shape, shape, std::vector<shape>, bool, bool, bool, int);
 bool draw_options(int);
 bool draw_sandbox(background_effect, shape, std::vector<shape>, bool, int, int);
-
-#endif

--- a/src/options.h
+++ b/src/options.h
@@ -1,5 +1,4 @@
-#ifndef options
-#define options
+#pragma once
 
 enum option_id {
     MUSIC,
@@ -23,5 +22,3 @@ std::string get_option_value(int);
 void move_option_selection(int);
 void modify_current_option_directions(int);
 int modify_current_option_button();
-
-#endif


### PR DESCRIPTION
`#pragma once` is a pre-processor directive which does the exact same thing as include guards, but with more [features](https://en.wikipedia.org/wiki/Pragma_once).