### PR TITLE
Implement Tutorial Mode

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 CXX := g++
 CXXFLAGS := -std=c++17 -Iinclude
 LDFLAGS := -lSDL2 -lSDL2_image -lSDL2_mixer -lstdc++fs
-OBJS = $(addprefix build/, main.o graphics.o character.o options.o)
+OBJS = $(addprefix build/, main.o graphics.o character.o options.o tutorial.o)
 EXECNAME = OpenManifold
 ICON = 
 

--- a/src/graphics.cpp
+++ b/src/graphics.cpp
@@ -2164,7 +2164,9 @@ bool draw_tutorial(int frame_time) {
     int grid_w = width/2 - (height/22 * 7.5);
     int grid_h = grid_y - (height/22 * 7.5);
     int grid_scale = height/22;
-    const int grid_positions[16][2] = {
+    
+    // used in TUT_GRID_MOVE and TUT_GRID_SIZE
+    const int grid_positions[][2] = {
         {7, 9},
         {8, 9},
         {9, 9},
@@ -2181,6 +2183,19 @@ bool draw_tutorial(int frame_time) {
         {5, 8},
         {5, 9},
         {6, 9}
+    };
+    
+    // used in TUT_CALL_RESP
+    // order is: x, y, scale
+    const int call_response_data[][3] = {
+        {7, 7, 1},
+        {7, 7, 2},
+        {7, 7, 3},
+        {7, 7, 3},
+        {7, 8, 3},
+        {7, 9, 3},
+        {7, 10, 3},
+        {7, 10, 3}
     };
     
     switch (get_tutorial_state()) {
@@ -2214,6 +2229,18 @@ bool draw_tutorial(int frame_time) {
         case TUT_GRID_SIZE:
             draw_grid(width/2, grid_y);
             draw_shape(0, 7, 7, grid_positions[time/120%16][0] - 3, {0, 0, 0, 255}, grid_w, grid_h, grid_scale);
+            break;
+            
+        case TUT_CALL_RESP:
+            draw_grid(width/2, grid_y);
+            draw_shape(0, call_response_data[time/240%8][0], call_response_data[time/240%8][1], call_response_data[time/240%8][2], get_rainbow_color(time), grid_w, grid_h, grid_scale);
+            
+            if (time/240%16 >= 8) {
+                draw_text("CPU", width/2, grid_h - (font->h * scale_mul), scale_mul, 0, width, {255, 0, 64, 255});
+            } else {
+                draw_text("PLAYER", width/2, grid_h - (font->h * scale_mul), scale_mul, 0, width, {64, 0, 255, 255});
+            }
+            
             break;
         
         case TUT_LIFE:

--- a/src/graphics.cpp
+++ b/src/graphics.cpp
@@ -2157,7 +2157,35 @@ bool draw_tutorial(int frame_time) {
     
     draw_gradient(0, 0, width, height, {192, 64, 255});
     draw_text("WORK IN PROGRESS", 0, height - (font->h*scale_mul), scale_mul, 1, width, {0, 0, 0});
-    draw_text(get_tutorial_current_message(), width/2, height/2, scale_mul, 0, width);
+    
+    // splits message into chunks    
+    string message = get_tutorial_current_message();
+    string temp;
+    std::vector<string> message_list;
+    int char_width = font->w/95;
+    int message_pixel_length = message.length() * char_width * scale_mul;
+    int max_line_length = width / (char_width * scale_mul);
+    
+    for (int i = 0; i < message.length(); i++) {
+        if (i % max_line_length == 0 && i != 0) {
+            int last_space = temp.find_last_of(" ");
+            string excess_text = temp.substr(last_space + 1, temp.length());
+            temp = temp.substr(0, last_space);
+            
+            message_list.push_back(temp);
+            temp = excess_text;
+        }
+    
+        temp += message[i];
+    }
+    
+    message_list.push_back(temp);
+    
+    // draws the split text
+    for (int i = 0; i < message_pixel_length; i+=width) {
+        int iteration = i/width;
+        draw_text(message_list[iteration], 0, height/2 + (font->h * scale_mul * iteration), scale_mul, 1, width);
+    }
     
     draw_fade(16, 16, frame_time);
     return true;

--- a/src/graphics.cpp
+++ b/src/graphics.cpp
@@ -2156,15 +2156,14 @@ bool draw_tutorial(int frame_time) {
     int scale_mul = fmax(floor(fmin(height, width)/360), 1);
     
     draw_gradient(0, 0, width, height, {192, 64, 255});
-    draw_text("WORK IN PROGRESS", 0, height - (font->h*scale_mul), scale_mul, 1, width, {0, 0, 0});
     
     // splits message into chunks    
     string message = get_tutorial_current_message();
     string temp;
     std::vector<string> message_list;
-    int char_width = font->w/95;
-    int message_pixel_length = message.length() * char_width * scale_mul;
-    int max_line_length = width / (char_width * scale_mul);
+    int char_width = floor(font->w/95) * scale_mul;
+    int message_pixel_length = message.length() * char_width;
+    int max_line_length = width / char_width;
     
     for (int i = 0; i < message.length(); i++) {
         if (i % max_line_length == 0 && i != 0) {
@@ -2184,7 +2183,7 @@ bool draw_tutorial(int frame_time) {
     // draws the split text
     for (int i = 0; i < message_pixel_length; i+=width) {
         int iteration = i/width;
-        draw_text(message_list[iteration], 0, height/2 + (font->h * scale_mul * iteration), scale_mul, 1, width);
+        draw_text(message_list[iteration], 0, (height - (font->h * scale_mul * message_list.size())) + (font->h * scale_mul * iteration) - 16, scale_mul, 1);
     }
     
     draw_fade(16, 16, frame_time);

--- a/src/graphics.cpp
+++ b/src/graphics.cpp
@@ -35,6 +35,7 @@
 #include "character.h"
 #include "background.h"
 #include "options.h"
+#include "tutorial.h"
 #include "font.h"
 
 using nlohmann::json;
@@ -2156,6 +2157,7 @@ bool draw_tutorial(int frame_time) {
     
     draw_gradient(0, 0, width, height, {192, 64, 255});
     draw_text("WORK IN PROGRESS", 0, height - (font->h*scale_mul), scale_mul, 1, width, {0, 0, 0});
+    draw_text(get_tutorial_current_message(), width/2, height/2, scale_mul, 0, width);
     
     draw_fade(16, 16, frame_time);
     return true;

--- a/src/graphics.cpp
+++ b/src/graphics.cpp
@@ -1706,7 +1706,7 @@ bool draw_title(int menu_selection, int frame_time) {
     // ----------------------------------------------------------
     // menu_selection: What is currently selected (range 0-3)
     
-    const char *menu_items[4] = {"Play", "Sandbox", "Options", "Quit"};
+    const char *menu_items[5] = {"Play", "Sandbox", "Tutorial", "Options", "Quit"};
 
     int scale_mul = fmax(floor(fmin(height, width)/360), 1);
     int char_height = font->h + 2;
@@ -1745,7 +1745,7 @@ bool draw_title(int menu_selection, int frame_time) {
     SDL_RenderFillRect(renderer, &rect);
 
     // draws menu items
-    for (int i = 0; i < 4; i++) {
+    for (int i = 0; i < 5; i++) {
         SDL_Color text_highlight = {255, 255, 255};
 
         if (i == menu_selection) {text_highlight = {255, 255, 96};}
@@ -2147,6 +2147,16 @@ bool draw_sandbox(background_effect background_id, shape active_shape, std::vect
         draw_text(sandbox_items[menu_item], width/2, height - icon_size - icon_padding - font->h, 1, 0);
     }
 
+    draw_fade(16, 16, frame_time);
+    return true;
+}
+
+bool draw_tutorial(int frame_time) {
+    int scale_mul = fmax(floor(fmin(height, width)/360), 1);
+    
+    draw_gradient(0, 0, width, height, {192, 64, 255});
+    draw_text("WORK IN PROGRESS", 0, height - (font->h*scale_mul), scale_mul, 1, width, {0, 0, 0});
+    
     draw_fade(16, 16, frame_time);
     return true;
 }

--- a/src/graphics.cpp
+++ b/src/graphics.cpp
@@ -2257,7 +2257,6 @@ bool draw_tutorial(int frame_time) {
     string temp;
     std::vector<string> message_list;
     int char_width = floor(font->w/95) * scale_mul;
-    int message_pixel_length = message.length() * char_width;
     int max_line_length = width / char_width;
     
     for (int i = 0; i < message.length(); i++) {
@@ -2276,8 +2275,8 @@ bool draw_tutorial(int frame_time) {
     message_list.push_back(temp);
     
     // draws the split text
-    for (int i = 0; i < message_pixel_length; i+=width) {
-        int iteration = i/width;
+    for (int i = 0; i < message.length(); i+=max_line_length) {
+        int iteration = i/max_line_length;
         draw_text(message_list[iteration], 0, (height - (font->h * scale_mul * message_list.size())) + (font->h * scale_mul * iteration) - 16, scale_mul, 1);
     }
     

--- a/src/graphics.cpp
+++ b/src/graphics.cpp
@@ -2157,6 +2157,7 @@ bool draw_tutorial(int frame_time) {
     int time = SDL_GetTicks();
     
     draw_gradient(0, 0, width, height, {192, 64, 255});
+    draw_menu_background(frame_time);
     
     // draws various things depending on what dialog is displaying
     int grid_y = height/2 - (font->h*scale_mul);

--- a/src/graphics.cpp
+++ b/src/graphics.cpp
@@ -2222,17 +2222,17 @@ bool draw_tutorial(int frame_time) {
             break;
         
         case TUT_GRID_MOVE:
-            draw_grid(width/2, grid_y);
+            draw_grid(width/2, grid_y, grid_scale);
             draw_shape(0, grid_positions[time/120%16][0], grid_positions[time/120%16][1], 1, {0, 0, 0, 255}, grid_w, grid_h, grid_scale);
             break;
         
         case TUT_GRID_SIZE:
-            draw_grid(width/2, grid_y);
+            draw_grid(width/2, grid_y, grid_scale);
             draw_shape(0, 7, 7, grid_positions[time/120%16][0] - 3, {0, 0, 0, 255}, grid_w, grid_h, grid_scale);
             break;
             
         case TUT_CALL_RESP:
-            draw_grid(width/2, grid_y);
+            draw_grid(width/2, grid_y, grid_scale);
             draw_shape(0, call_response_data[time/240%8][0], call_response_data[time/240%8][1], call_response_data[time/240%8][2], get_rainbow_color(time), grid_w, grid_h, grid_scale);
             
             if (time/240%16 >= 8) {

--- a/src/graphics.cpp
+++ b/src/graphics.cpp
@@ -2154,8 +2154,75 @@ bool draw_sandbox(background_effect background_id, shape active_shape, std::vect
 
 bool draw_tutorial(int frame_time) {
     int scale_mul = fmax(floor(fmin(height, width)/360), 1);
+    int time = SDL_GetTicks();
     
     draw_gradient(0, 0, width, height, {192, 64, 255});
+    
+    // draws various things depending on what dialog is displaying
+    int grid_y = height/2 - (font->h*scale_mul);
+    int grid_w = width/2 - (height/22 * 7.5);
+    int grid_h = grid_y - (height/22 * 7.5);
+    int grid_scale = height/22;
+    const int grid_positions[16][2] = {
+        {7, 9},
+        {8, 9},
+        {9, 9},
+        {9, 8},
+        {9, 7},
+        {9, 6},
+        {9, 5},
+        {8, 5},
+        {7, 5},
+        {6, 5},
+        {5, 5},
+        {5, 6},
+        {5, 7},
+        {5, 8},
+        {5, 9},
+        {6, 9}
+    };
+    
+    switch (get_tutorial_state()) {
+        case TUT_FACE:
+            draw_shape(0, 7, 7, 7,  {255, 255, 255, 255}, grid_w, grid_h, grid_scale);
+            draw_shape(0, 3, 6, 2,  {0, 0, 0, 255},       grid_w, grid_h, grid_scale);
+            draw_shape(0, 11, 6, 2, {0, 0, 0, 255},       grid_w, grid_h, grid_scale);
+            draw_shape(0, 7, 10, 3, {0, 0, 0, 255},       grid_w, grid_h, grid_scale);
+            draw_shape(0, 7, 9, 3,  {255, 255, 255, 255}, grid_w, grid_h, grid_scale);
+            break;
+        
+        case TUT_SHAPES:
+            draw_shape_outline(0, -3, 7, 6, get_rainbow_color(time), grid_w, grid_h + (sin(time/400.f) * (height/32)), grid_scale);
+            draw_shape_outline(1, 7, 7, 6, get_rainbow_color(time+200), grid_w, grid_h + (sin(time/400.f + 400) * (height/32)), grid_scale);
+            draw_shape_outline(2, 17, 7, 6, get_rainbow_color(time+400), grid_w, grid_h + (sin(time/400.f + 800) * (height/32)), grid_scale);
+            draw_shape(0, -3, 7, 4, {255, 255, 255, 255}, grid_w, grid_h, grid_scale);
+            draw_shape(1, 7, 7, 4, {255, 255, 255, 255}, grid_w, grid_h, grid_scale);
+            draw_shape(2, 17, 7, 4, {255, 255, 255, 255}, grid_w, grid_h, grid_scale);
+            break;
+        
+        case TUT_GRID_TYPE:
+            draw_grid(width/2, grid_y, grid_scale);
+            draw_shape(time/240 % 3, 7, 7, 1, {0, 0, 0, 255}, grid_w, grid_h, grid_scale);
+            break;
+        
+        case TUT_GRID_MOVE:
+            draw_grid(width/2, grid_y);
+            draw_shape(0, grid_positions[time/120%16][0], grid_positions[time/120%16][1], 1, {0, 0, 0, 255}, grid_w, grid_h, grid_scale);
+            break;
+        
+        case TUT_GRID_SIZE:
+            draw_grid(width/2, grid_y);
+            draw_shape(0, 7, 7, grid_positions[time/120%16][0] - 3, {0, 0, 0, 255}, grid_w, grid_h, grid_scale);
+            break;
+        
+        case TUT_LIFE:
+            draw_hud(100 - (time/100 % 100), 0, time, frame_time);
+            break;
+        
+        case TUT_NONE:
+        default:
+            break;
+    }
     
     // splits message into chunks    
     string message = get_tutorial_current_message();

--- a/src/graphics.h
+++ b/src/graphics.h
@@ -46,3 +46,4 @@ bool draw_level_select(std::vector<shape>, int);
 bool draw_game(int, int, int, int, float, int, int, bool, bool, background_effect, shape, shape, std::vector<shape>, bool, bool, bool, int);
 bool draw_options(int);
 bool draw_sandbox(background_effect, shape, std::vector<shape>, bool, bool, int, int);
+bool draw_tutorial(int);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1950,8 +1950,9 @@ int main(int argc, char *argv[]) {
                                 switch (menu_selected) {
                                     case 0: transition_state =  STAGE_SELECT;   break;
                                     case 1: transition_state =  SANDBOX;    break;
-                                    case 2: transition_state =  OPTIONS;    break;
-                                    case 3: transition_state =  EXIT;   break;
+                                    case 2: transition_state =  TUTORIAL;   break;
+                                    case 3: transition_state =  OPTIONS;    break;
+                                    case 4: transition_state =  EXIT;   break;
                                 }
 
                                 fade_out++;
@@ -1962,7 +1963,7 @@ int main(int argc, char *argv[]) {
                             case CIRCLE:
                                 if (check_fade_activity()) {break;}
                                 Mix_PlayChannel(0, snd_menu_confirm, 0);
-                                menu_selected = 3;
+                                menu_selected = 4;
                                 transition_state = EXIT;
                                 fade_out++;
                                 break;
@@ -1973,8 +1974,8 @@ int main(int argc, char *argv[]) {
                                     menu_selected--;
                                 }
 
-                            if (menu_selected > 3) {menu_selected = 0;}
-                            if (menu_selected < 0) {menu_selected = 3;}
+                            if (menu_selected > 4) {menu_selected = 0;}
+                            if (menu_selected < 0) {menu_selected = 4;}
 
                             break;
 
@@ -1984,8 +1985,8 @@ int main(int argc, char *argv[]) {
                                     menu_selected++;
                                 }
 
-                            if (menu_selected > 3) {menu_selected = 0;}
-                            if (menu_selected < 0) {menu_selected = 3;}
+                            if (menu_selected > 4) {menu_selected = 0;}
+                            if (menu_selected < 0) {menu_selected = 4;}
 
                             break;
 
@@ -2288,6 +2289,17 @@ int main(int argc, char *argv[]) {
                             }
                         }
                         break;
+                        
+                    case TUTORIAL:
+                        switch(input_value) {
+                            case SELECT:
+                                if (check_fade_activity()) {break;}
+                                Mix_PlayChannel(0, snd_menu_confirm, 0);
+                                transition_state = TITLE;
+                                fade_out++;
+                                break;
+                        }
+                        break;
 
                     case OPTIONS:
                         if (check_rebind()) {
@@ -2398,6 +2410,10 @@ int main(int argc, char *argv[]) {
                     load_default_music("menu");
                     break;
                     
+                case TUTORIAL:
+                    load_default_music("menu");
+                    break;
+                    
                 case STAGE_SELECT:
                     previous_shapes.clear();
                     break;
@@ -2435,7 +2451,7 @@ int main(int argc, char *argv[]) {
                     }
 
                     break;
-
+                    
                 case SANDBOX:
                     printf("Loading sandbox mode...\n");
                     draw_loading(false);
@@ -2450,6 +2466,11 @@ int main(int argc, char *argv[]) {
                     sandbox_menu_active = false;
                     sandbox_option_selected = 0;
                     sandbox_lock = false;
+                    break;
+                    
+                case TUTORIAL:
+                    printf("Loading tutorial mode...\n");
+                    load_default_music("tutorial");
                     break;
 
                 case GAME:
@@ -2503,6 +2524,10 @@ int main(int argc, char *argv[]) {
 
             case SANDBOX:
                 draw_sandbox(background_id, active_shape, previous_shapes, sandbox_menu_active, sandbox_lock, sandbox_option_selected, frame_time);
+                break;
+            
+            case TUTORIAL:
+                draw_tutorial(frame_time);
                 break;
 
             case OPTIONS:

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -40,6 +40,7 @@
 #include "background.h"
 #include "character.h"
 #include "options.h"
+#include "tutorial.h"
 #include "version.h"
 
 using nlohmann::json;
@@ -2298,6 +2299,10 @@ int main(int argc, char *argv[]) {
                                 transition_state = TITLE;
                                 fade_out++;
                                 break;
+                                
+                            case CROSS:
+                                tutorial_advance_message();
+                                break;
                         }
                         break;
 
@@ -2470,6 +2475,7 @@ int main(int argc, char *argv[]) {
                     
                 case TUTORIAL:
                     printf("Loading tutorial mode...\n");
+                    init_tutorial();
                     load_default_music("tutorial");
                     break;
 
@@ -2527,6 +2533,7 @@ int main(int argc, char *argv[]) {
                 break;
             
             case TUTORIAL:
+                tutorial_message_tick(frame_time);
                 draw_tutorial(frame_time);
                 break;
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -2313,7 +2313,14 @@ int main(int argc, char *argv[]) {
                                 break;
                                 
                             case CROSS:
+                                if (check_fade_activity()) {break;}
+                                
                                 tutorial_advance_message();
+                                
+                                if (check_tutorial_finished()) {
+                                    transition_state = TITLE;
+                                    fade_out++;
+                                }
                                 break;
                         }
                         break;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -586,6 +586,18 @@ void play_channel_test() {
     return;
 }
 
+void play_dialog_blip() {
+    // called from tutorial.cpp
+    Mix_PlayChannel(-1, snd_metronome_big, 0);
+    return;
+}
+
+void play_dialog_advance() {
+    // called from tutorial.cpp
+    Mix_PlayChannel(-1, snd_menu_confirm, 0);
+    return;
+}
+
 void set_vsync_renderer() {
     // sets VSYNC flag in SDL2 and re-creates the renderer
     SDL_SetHint(SDL_HINT_RENDER_VSYNC, std::to_string(vsync_toggle).c_str());

--- a/src/main.h
+++ b/src/main.h
@@ -17,6 +17,8 @@ void set_sfx_volume();
 void set_fullscreen();
 void set_channel_mix();
 void play_channel_test();
+void play_dialog_blip();
+void play_dialog_advance();
 void set_vsync_renderer();
 void set_frame_cap_ms();
 void init_controller();

--- a/src/tutorial.cpp
+++ b/src/tutorial.cpp
@@ -25,6 +25,8 @@
 #include <cstdlib>
 #include <string>
 
+#include "main.h"
+
 using std::string;
 
 int message_index = 0;
@@ -63,15 +65,20 @@ void tutorial_message_tick(int frame_time) {
     if (message_tick <= 0) {
         current_message.append(messages[message_index], current_message.length(), 1);
         message_tick = message_tick_rate;
+        
+        if (current_message.length() % 4 == 0) {
+            play_dialog_blip();
+        }
     }
     
     return;
 }
 
 void tutorial_advance_message() {
-    message_tick_rate = 15;
+    message_tick_rate = 5;
     
     if (message_finished && message_index < std::size(messages) - 1) {
+        play_dialog_advance();
         current_message.clear();
         message_index++;
         message_tick_rate = 30;

--- a/src/tutorial.cpp
+++ b/src/tutorial.cpp
@@ -29,6 +29,15 @@
 
 using std::string;
 
+enum tutorial_states {
+    TUT_NONE,
+    TUT_FACE,
+    TUT_SHAPES,
+    TUT_GRID_MOVE,
+    TUT_GRID_SIZE,
+    TUT_LIFEBAR
+};
+
 int message_index = 0;
 int message_tick = 0;
 int message_tick_rate = 30;
@@ -36,13 +45,16 @@ bool message_finished = false;
 string current_message;
 
 string messages[] = {
-    "Message 1",
-    "Massage Two",
-    "Messenger Tres",
-    "Mortgage 4our",
-    "Fifth set of informative combination of words for your reading entertainment or education or hopefully something along those lines anyways because these things take quite a bit of effort to write and definitely isn't just padding for the sake of having a long message to test this function with",
-    "Okay but really these are placeholder lines",
-    "This mode is nowhere near finished so come back later maybe xoxo love you <3"
+    "Welcome to Open Manifold! In this guide, we will walk through the basics of playing the game.",
+    "Open Manifold is a rhythm game where the goal is to create patterns called 'faces'.",
+    "To make faces, you create and manipulate shapes. There are three kinds of shapes: circles, squares, and triangles.",
+    "To create a shape, press one of the three face buttons. Each button corresponds to one shape.",
+    "You can freely move the shape's position along the grid with the directional buttons. ",
+    "You can also resize the shape with the shoulder buttons. The shape can be resized anywhere, even at the edges of the grid.",
+    "Every shape has two 'phases'. In the first phase, the computer will create a shape and move it into position. In the second phase, you must replicate that shape.",
+    "Your actions must be timed to the beat of the song. If your timing isn't on-beat, nothing will happen. You only get so many beats to work with, so make them count!",
+    "You also have a lifebar. Fail to replicate a shape, and you'll lose some life. Complete a shape, and you'll get some of it back. If it hits zero, that's a game over!",
+    "That should cover the basics of play. Have fun, and enjoy Open Manifold!"
 };
 
 void init_tutorial() {

--- a/src/tutorial.cpp
+++ b/src/tutorial.cpp
@@ -42,6 +42,7 @@ int message_index = 0;
 int message_tick = 0;
 int message_tick_rate = 30;
 bool message_finished = false;
+bool tutorial_finished = false;
 string current_message;
 
 string messages[] = {
@@ -62,6 +63,7 @@ void init_tutorial() {
     message_tick = 0;
     message_tick_rate = 30;
     message_finished = false;
+    tutorial_finished = false;
     current_message.clear();
     return;
 }
@@ -69,13 +71,13 @@ void init_tutorial() {
 void tutorial_message_tick(int frame_time) {
     message_tick -= frame_time;
     
-    if (current_message.length() == messages[message_index].length()) {
+    if (current_message.length() == messages[message_index].msg.length()) {
         message_finished = true;
         return;
     }
     
     if (message_tick <= 0) {
-        current_message.append(messages[message_index], current_message.length(), 1);
+        current_message.append(messages[message_index].msg, current_message.length(), 1);
         message_tick = message_tick_rate;
         
         if (current_message.length() % 4 == 0) {
@@ -89,13 +91,18 @@ void tutorial_message_tick(int frame_time) {
 void tutorial_advance_message() {
     message_tick_rate = 5;
     
-    if (message_finished && message_index < std::size(messages) - 1) {
+    if (message_finished && !tutorial_finished) {
         play_dialog_advance();
-        current_message.clear();
-        message_index++;
-        message_tick_rate = 30;
-        message_tick = message_tick_rate;
-        message_finished = false;
+        
+        if (message_index >= std::size(messages) - 1) {
+            tutorial_finished = true;
+        } else {
+            current_message.clear();
+            message_index++;
+            message_tick_rate = 30;
+            message_tick = message_tick_rate;
+            message_finished = false;
+        }
     }
     
     return;
@@ -103,4 +110,12 @@ void tutorial_advance_message() {
 
 string get_tutorial_current_message() {
     return current_message;
+}
+
+tutorial_states get_tutorial_state() {
+    return messages[message_index].state;
+}
+
+bool check_tutorial_finished() {
+    return tutorial_finished;
 }

--- a/src/tutorial.cpp
+++ b/src/tutorial.cpp
@@ -1,0 +1,82 @@
+/*  Open Manifold source file
+*
+*   This program/source code is licensed under the MIT License:
+*
+*   Permission is hereby granted, free of charge, to any person obtaining a copy
+*   of this software and associated documentation files (the "Software"), to deal
+*   in the Software without restriction, including without limitation the rights
+*   to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+*   copies of the Software, and to permit persons to whom the Software is
+*   furnished to do so, subject to the following conditions:
+*
+*   The above copyright notice and this permission notice shall be included in all
+*   copies or substantial portions of the Software.
+*
+*   THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+*   IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+*   FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+*   AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+*   LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+*   OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+*   SOFTWARE.
+*
+*/
+
+#include <cstdlib>
+#include <string>
+
+using std::string;
+
+int message_index = 0;
+int message_tick = 0;
+bool message_finished = false;
+string current_message;
+
+string messages[] = {
+    "Message 1",
+    "Massage Two",
+    "Messenger Tres",
+    "Mortgage 4our",
+    "Fifth set of informative combination of words for your reading entertainment or education or hopefully something along those lines anyways because these things take quite a bit of effort to write and definitely isn't just padding for the sake of having a long message to test this function with",
+    "Okay but really these are placeholder lines",
+    "This mode is nowhere near finished so come back later maybe xoxo love you <3"
+};
+
+void init_tutorial() {
+    message_index = 0;
+    message_tick = 0;
+    message_finished = false;
+    current_message.clear();
+    return;
+}
+
+void tutorial_message_tick(int frame_time) {
+    message_tick -= frame_time;
+    
+    if (current_message.length() == messages[message_index].length()) {
+        message_finished = true;
+        return;
+    }
+    
+    if (message_tick <= 0) {
+        current_message.append(messages[message_index], current_message.length(), 1);
+        message_tick = 40;
+    }
+    
+    return;
+}
+
+void tutorial_advance_message() {
+    if (message_finished && message_index < std::size(messages) - 1) {
+        current_message.clear();
+        message_index++;
+        message_tick = 40;
+        message_finished = false;
+    }
+    
+    return;
+}
+
+string get_tutorial_current_message() {
+    return current_message;
+}

--- a/src/tutorial.cpp
+++ b/src/tutorial.cpp
@@ -33,9 +33,10 @@ enum tutorial_states {
     TUT_NONE,
     TUT_FACE,
     TUT_SHAPES,
+    TUT_GRID_TYPE,
     TUT_GRID_MOVE,
     TUT_GRID_SIZE,
-    TUT_LIFEBAR
+    TUT_LIFE
 };
 
 int message_index = 0;
@@ -45,17 +46,20 @@ bool message_finished = false;
 bool tutorial_finished = false;
 string current_message;
 
-string messages[] = {
-    "Welcome to Open Manifold! In this guide, we will walk through the basics of playing the game.",
-    "Open Manifold is a rhythm game where the goal is to create patterns called 'faces'.",
-    "To make faces, you create and manipulate shapes. There are three kinds of shapes: circles, squares, and triangles.",
-    "To create a shape, press one of the three face buttons. Each button corresponds to one shape.",
-    "You can freely move the shape's position along the grid with the directional buttons. ",
-    "You can also resize the shape with the shoulder buttons. The shape can be resized anywhere, even at the edges of the grid.",
-    "Every shape has two 'phases'. In the first phase, the computer will create a shape and move it into position. In the second phase, you must replicate that shape.",
-    "Your actions must be timed to the beat of the song. If your timing isn't on-beat, nothing will happen. You only get so many beats to work with, so make them count!",
-    "You also have a lifebar. Fail to replicate a shape, and you'll lose some life. Complete a shape, and you'll get some of it back. If it hits zero, that's a game over!",
-    "That should cover the basics of play. Have fun, and enjoy Open Manifold!"
+struct {
+    tutorial_states state;
+    string msg;
+} messages[] = {
+    TUT_NONE, "Welcome to Open Manifold! In this guide, we will walk through the basics of playing the game.",
+    TUT_FACE, "Open Manifold is a rhythm game where the goal is to create patterns called 'faces'.",
+    TUT_SHAPES, "To make faces, you create and manipulate shapes. There are three kinds of shapes: circles, squares, and triangles.",
+    TUT_GRID_TYPE, "To create a shape, press one of the three face buttons. Each button corresponds to one shape.",
+    TUT_GRID_MOVE, "You can freely move the shape's position along the grid with the directional buttons. ",
+    TUT_GRID_SIZE, "You can also resize the shape with the shoulder buttons. The shape can be resized anywhere, even at the edges of the grid.",
+    TUT_NONE, "Your actions must be timed to the beat of the song. If your input timing isn't on-beat, then nothing will happen. You only get so many beats to work with, so make 'em count!",
+    TUT_NONE, "Every shape has two 'phases'. In the first phase, the computer will create a shape and move it into position. In the second phase, you must replicate that shape.",
+    TUT_LIFE, "You also have a lifebar. Fail to replicate a shape, and you'll lose some life. Complete a shape, and you'll get some of it back. If it hits zero, that's a game over!",
+    TUT_NONE, "That should cover the basics of play. Have fun, and enjoy playing Open Manifold!"
 };
 
 void init_tutorial() {

--- a/src/tutorial.cpp
+++ b/src/tutorial.cpp
@@ -36,6 +36,7 @@ enum tutorial_states {
     TUT_GRID_TYPE,
     TUT_GRID_MOVE,
     TUT_GRID_SIZE,
+    TUT_CALL_RESP,
     TUT_LIFE
 };
 
@@ -57,7 +58,7 @@ struct {
     TUT_GRID_MOVE, "You can freely move the shape's position along the grid with the directional buttons. ",
     TUT_GRID_SIZE, "You can also resize the shape with the shoulder buttons. The shape can be resized anywhere, even at the edges of the grid.",
     TUT_NONE, "Your actions must be timed to the beat of the song. If your input timing isn't on-beat, then nothing will happen. You only get so many beats to work with, so make 'em count!",
-    TUT_NONE, "Levels play out in a call-and-response fashion. First the computer will create a shape and move it into position, and then you must replicate that shape.",
+    TUT_CALL_RESP, "Levels play out in a call-and-response fashion. First the computer will create a shape and move it into position, and then you must replicate that shape.",
     TUT_LIFE, "You also have a lifebar. Fail to replicate a shape, and you'll lose some life. Complete a shape, and you'll get some of it back. If it hits zero, that's a game over!",
     TUT_FACE, "That should cover the basics of play. Have fun, and enjoy playing Open Manifold!"
 };

--- a/src/tutorial.cpp
+++ b/src/tutorial.cpp
@@ -57,9 +57,9 @@ struct {
     TUT_GRID_MOVE, "You can freely move the shape's position along the grid with the directional buttons. ",
     TUT_GRID_SIZE, "You can also resize the shape with the shoulder buttons. The shape can be resized anywhere, even at the edges of the grid.",
     TUT_NONE, "Your actions must be timed to the beat of the song. If your input timing isn't on-beat, then nothing will happen. You only get so many beats to work with, so make 'em count!",
-    TUT_NONE, "Every shape has two 'phases'. In the first phase, the computer will create a shape and move it into position. In the second phase, you must replicate that shape.",
+    TUT_NONE, "Levels play out in a call-and-response fashion. First the computer will create a shape and move it into position, and then you must replicate that shape.",
     TUT_LIFE, "You also have a lifebar. Fail to replicate a shape, and you'll lose some life. Complete a shape, and you'll get some of it back. If it hits zero, that's a game over!",
-    TUT_NONE, "That should cover the basics of play. Have fun, and enjoy playing Open Manifold!"
+    TUT_FACE, "That should cover the basics of play. Have fun, and enjoy playing Open Manifold!"
 };
 
 void init_tutorial() {

--- a/src/tutorial.cpp
+++ b/src/tutorial.cpp
@@ -29,6 +29,7 @@ using std::string;
 
 int message_index = 0;
 int message_tick = 0;
+int message_tick_rate = 30;
 bool message_finished = false;
 string current_message;
 
@@ -45,6 +46,7 @@ string messages[] = {
 void init_tutorial() {
     message_index = 0;
     message_tick = 0;
+    message_tick_rate = 30;
     message_finished = false;
     current_message.clear();
     return;
@@ -60,17 +62,20 @@ void tutorial_message_tick(int frame_time) {
     
     if (message_tick <= 0) {
         current_message.append(messages[message_index], current_message.length(), 1);
-        message_tick = 40;
+        message_tick = message_tick_rate;
     }
     
     return;
 }
 
 void tutorial_advance_message() {
+    message_tick_rate = 15;
+    
     if (message_finished && message_index < std::size(messages) - 1) {
         current_message.clear();
         message_index++;
-        message_tick = 40;
+        message_tick_rate = 30;
+        message_tick = message_tick_rate;
         message_finished = false;
     }
     

--- a/src/tutorial.h
+++ b/src/tutorial.h
@@ -1,10 +1,5 @@
 #pragma once 
 
-void init_tutorial();
-void tutorial_message_tick(int);
-void tutorial_advance_message();
-std::string get_tutorial_current_message();
-
 enum tutorial_states {
     TUT_NONE,
     TUT_FACE,
@@ -13,3 +8,10 @@ enum tutorial_states {
     TUT_GRID_SIZE,
     TUT_LIFEBAR
 };
+
+void init_tutorial();
+void tutorial_message_tick(int);
+void tutorial_advance_message();
+std::string get_tutorial_current_message();
+tutorial_states get_tutorial_state();
+bool check_tutorial_finished();

--- a/src/tutorial.h
+++ b/src/tutorial.h
@@ -7,6 +7,7 @@ enum tutorial_states {
     TUT_GRID_TYPE,
     TUT_GRID_MOVE,
     TUT_GRID_SIZE,
+    TUT_CALL_RESP,
     TUT_LIFE
 };
 

--- a/src/tutorial.h
+++ b/src/tutorial.h
@@ -4,3 +4,12 @@ void init_tutorial();
 void tutorial_message_tick(int);
 void tutorial_advance_message();
 std::string get_tutorial_current_message();
+
+enum tutorial_states {
+    TUT_NONE,
+    TUT_FACE,
+    TUT_SHAPES,
+    TUT_GRID_MOVE,
+    TUT_GRID_SIZE,
+    TUT_LIFEBAR
+};

--- a/src/tutorial.h
+++ b/src/tutorial.h
@@ -4,9 +4,10 @@ enum tutorial_states {
     TUT_NONE,
     TUT_FACE,
     TUT_SHAPES,
+    TUT_GRID_TYPE,
     TUT_GRID_MOVE,
     TUT_GRID_SIZE,
-    TUT_LIFEBAR
+    TUT_LIFE
 };
 
 void init_tutorial();

--- a/src/tutorial.h
+++ b/src/tutorial.h
@@ -1,0 +1,6 @@
+#pragma once 
+
+void init_tutorial();
+void tutorial_message_tick(int);
+void tutorial_advance_message();
+std::string get_tutorial_current_message();


### PR DESCRIPTION
This PR adds a tutorial mode to Open Manifold. It's a rather simple implementation, effectively a fancy visual-novel-esque manual with no directly-interactive bits, but it works well enough and it can always be refined down the road.

This PR adds two new files, `tutorial.cpp` and `tutorial.h`, and also makes use of the previously-unused `tutorial.ogg` and `draw_shape_outline()` function as well as the otherwise-seldom-used `sounds/metronome_big.ogg`, for background music and "dialog blips" respectively.

Some screenshots (not every part of the tutorial, but a good chunk of it:)
<img src="https://user-images.githubusercontent.com/22881403/235636196-33115e91-f032-4d44-8047-deaf57608c3d.png" width="640" height="360">
<img src="https://user-images.githubusercontent.com/22881403/235636199-001df6c6-6c0b-44c3-b784-bdc5ff0b4710.png" width="640" height="360">
<img src="https://user-images.githubusercontent.com/22881403/235636200-6f8b7c66-96d2-431d-9b49-1fb300e4a852.png" width="640" height="360">
<img src="https://user-images.githubusercontent.com/22881403/235636202-237d8fd2-c50f-4be8-84d2-b0fdbf463936.png" width="640" height="360">

Solves #4.